### PR TITLE
fix: retry on RemoteDisconnected

### DIFF
--- a/src/upparat/statemachine/download.py
+++ b/src/upparat/statemachine/download.py
@@ -5,6 +5,7 @@ import threading
 import urllib.request
 from urllib.error import HTTPError
 from urllib.error import URLError
+from http.client import RemoteDisconnected
 
 import backoff
 import pysm
@@ -25,7 +26,7 @@ REQUEST_TIMEOUT_SEC = 30
 
 
 @backoff.on_exception(
-    backoff.expo, (URLError, HTTPError, socket.timeout), jitter=backoff.full_jitter
+    backoff.expo, (URLError, HTTPError, RemoteDisconnected, socket.timeout), jitter=backoff.full_jitter
 )
 def download(job, stop_download, publish, update_job_progress):
     start_position_bytes = 0


### PR DESCRIPTION
Hi Philipp,

this should fix the issue you’re facing. We are a bit careful for which cases we retry the download (to prevent being stuck), so this is will happen for a couple of exceptions in the future.

P.S. Since I’m currently in a bus, writing this on my phone I haven’t been able to test this nor updated the test. :) However, I’m fairly sure this will fix it and I wanted to save you some time in case this becomes urgent.

Best,
Livio

