### PR TITLE
Pass elapsed time to hooks instead of time of first call

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     include_package_data=True,
     install_requires=["paho-mqtt>=1.4.0", "backoff>=1.8.1", "pysm>=0.3.7"],
     extras_require={
-        "dev": ["pytest", "pytest-mock", "boto3", "ipdb", "freezegun", "coverage"],
+        "dev": ["pytest", "pytest-mock", "boto3", "ipdb", "coverage"],
         "sentry": ["sentry-sdk"],
     },
     entry_points={"console_scripts": ["upparat=upparat.cli:main"]},

--- a/src/upparat/hooks.py
+++ b/src/upparat/hooks.py
@@ -1,8 +1,8 @@
 import logging
 import subprocess
 import threading
-import time
 from queue import Queue
+from timeit import default_timer
 
 import pysm
 
@@ -34,12 +34,14 @@ def _hook(hook, stop_event, inbox: Queue, args: list):
     max_retries = settings.hooks.max_retries
     retry_interval = settings.hooks.retry_interval
 
-    first_call = int(time.time())
+    first_call_timer = default_timer()
 
     while retry < max_retries and not stop_event.is_set():
+        time_elapsed = int(default_timer() - first_call_timer)
+
         # universal_newlines=True and bufsize 1 means line buffered
         with subprocess.Popen(
-            [hook, str(first_call), str(retry)] + args,
+            [hook, str(time_elapsed), str(retry)] + args,
             stdout=subprocess.PIPE,
             universal_newlines=True,
             bufsize=1,

--- a/tests/integration/upparat/hooks/download.sh
+++ b/tests/integration/upparat/hooks/download.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Check if download is allowed right now.
 #
-# $1: timestamp from first call
+# $1: time elapsed since the first call
 # $2: retry count
 # $3: meta from job document
 # $4: file location

--- a/tests/integration/upparat/hooks/install.sh
+++ b/tests/integration/upparat/hooks/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Installs the provided file
 #
-# $1: timestamp from first call
+# $1: time elapsed since the first call
 # $2: retry count
 # $3: meta from job document
 # $4: file location

--- a/tests/integration/upparat/hooks/restart.sh
+++ b/tests/integration/upparat/hooks/restart.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Installs the provided file
 #
-# $1: timestamp from first call
+# $1: time elapsed since the first call
 # $2: retry count
 # $3: meta from job document
 

--- a/tests/integration/upparat/hooks/version.sh
+++ b/tests/integration/upparat/hooks/version.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Gets the system version
 #
-# $1: timestamp from first call
+# $1: time elapsed since the first call
 # $2: retry count
 # $3: meta from job document
 


### PR DESCRIPTION
prevent issues with incorrectly set time.