### PR TITLE
Prevents subsequent Upparat jobs from hanging if job gets force cancelled.

### DIFF
--- a/src/upparat/statemachine/download.py
+++ b/src/upparat/statemachine/download.py
@@ -132,6 +132,9 @@ class DownloadState(JobProcessingState):
                 os.remove(download_file_path)
 
     def start_download_thread(self):
+        # event could still be set from the previous job
+        # that has been cancelled or deleted, so clear it.
+        self.stop_download.clear()
         self.clean_previous_downloads()
 
         logger.debug(f"Start download for job {self.job.id_}.")

--- a/tests/statemachine/download_test.py
+++ b/tests/statemachine/download_test.py
@@ -73,6 +73,20 @@ def download_state(mocker, tmpdir):
     return state, inbox, mqtt_client, statemachine, run_hook
 
 
+def test_on_enter_clear_stop_event(mocker, download_state, urllib_urlopen_mock):
+    mocker.patch("urllib.request.urlopen", urllib_urlopen_mock())
+    state, inbox, _, _, _ = download_state
+
+    # previous job got cancelled
+    state.on_job_cancelled(None, None)
+
+    # next job should clear event
+    # before starting the download
+    state.on_enter(None, None)
+
+    assert not state.stop_download.is_set()
+
+
 def test_download_completed_on_http_416(mocker, download_state, urllib_urlopen_mock):
     side_effect = create_http_error(416)
     urlopen_mock = urllib_urlopen_mock(side_effect)


### PR DESCRIPTION
Mitigates a bug where if a job gets (force) cancelled or deleted (while in download), Upparat would hang in download for subsequent jobs since the `stop_event` in the download state never gets cleared and remains set till Upparat restarts. *Whoopsie* :trollface:.

closes https://github.com/caruhome/upparat/issues/8.

*👆thanks Philipp, nice catch during testing!*