### PR TITLE
Ignore non-Upparat AWS IoT Jobs

### DIFF
--- a/misc/upparat_create_job.py
+++ b/misc/upparat_create_job.py
@@ -169,6 +169,9 @@ def main(arguments):
     print(f" → ARN IoT: {arguments.arn_iot}")
     print(f" → Things: {thing_names}")
     print(f" → Groups: {group_names}\n")
+    print(f"AWS IoT Job Document:\n")
+    print(json.dumps(json.loads(document), indent=2))
+    print("")
 
     if not arguments.dry_run:
         create_job(

--- a/src/upparat/events.py
+++ b/src/upparat/events.py
@@ -11,6 +11,7 @@ JOB_VERIFIED = "job-verified"
 JOB_REVOKED = "job-revoked"
 
 SELECT_JOB_INTERRUPTED = "selected-job-interrupted"
+SELECT_JOB_ACTION_MISMATCH = "selected-job-action-mismatch"
 
 DOWNLOAD_COMPLETED = "download-completed"
 DOWNLOAD_INTERRUPTED = "download-interrupted"

--- a/src/upparat/jobs.py
+++ b/src/upparat/jobs.py
@@ -4,6 +4,8 @@ from enum import Enum
 
 from upparat.config import settings
 
+UPPARAT_ACTION = "upparat-update"
+
 # AWS job execution
 EXECUTION = "execution"
 EXECUTION_STATE = "executionState"
@@ -14,6 +16,7 @@ JOBS = "jobs"
 # AWS job document
 JOB_ID = "jobId"
 JOB_DOCUMENT = "jobDocument"
+JOB_DOCUMENT_ACTION = "action"
 JOB_DOCUMENT_FILE = "file"
 JOB_DOCUMENT_VERSION = "version"
 JOB_DOCUMENT_META = "meta"

--- a/src/upparat/statemachine/machine.py
+++ b/src/upparat/statemachine/machine.py
@@ -13,6 +13,7 @@ from upparat.events import JOB_VERIFIED
 from upparat.events import JOBS_AVAILABLE
 from upparat.events import NO_JOBS_PENDING
 from upparat.events import RESTART_INTERRUPTED
+from upparat.events import SELECT_JOB_ACTION_MISMATCH
 from upparat.events import SELECT_JOB_INTERRUPTED
 from upparat.statemachine import UpparatStateMachine
 from upparat.statemachine.download import DownloadState
@@ -69,6 +70,10 @@ def create_statemachine(event_queue, mqtt_client):
     # Pending jobs got modified (rejected) meanwhile
     statemachine.add_transition(
         select_job_state, fetch_jobs_state, events=[SELECT_JOB_INTERRUPTED]
+    )
+
+    statemachine.add_transition(
+        select_job_state, monitor_state, events=[SELECT_JOB_ACTION_MISMATCH]
     )
 
     # Job is ready for process

--- a/src/upparat/statemachine/select_job.py
+++ b/src/upparat/statemachine/select_job.py
@@ -14,6 +14,7 @@ from upparat.events import MQTT_EVENT_PAYLOAD
 from upparat.events import MQTT_EVENT_TOPIC
 from upparat.events import MQTT_MESSAGE_RECEIVED
 from upparat.events import MQTT_SUBSCRIBED
+from upparat.events import SELECT_JOB_ACTION_MISMATCH
 from upparat.events import SELECT_JOB_INTERRUPTED
 from upparat.jobs import describe_job_execution
 from upparat.jobs import describe_job_execution_response
@@ -21,6 +22,7 @@ from upparat.jobs import EXECUTION
 from upparat.jobs import Job
 from upparat.jobs import JOB_ACCEPTED
 from upparat.jobs import JOB_DOCUMENT
+from upparat.jobs import JOB_DOCUMENT_ACTION
 from upparat.jobs import JOB_DOCUMENT_FILE
 from upparat.jobs import JOB_DOCUMENT_FORCE
 from upparat.jobs import JOB_DOCUMENT_META
@@ -32,6 +34,7 @@ from upparat.jobs import JOB_STATUS
 from upparat.jobs import JOB_STATUS_DETAILS
 from upparat.jobs import job_update_multiple_as_failed
 from upparat.jobs import JobProgressStatus
+from upparat.jobs import UPPARAT_ACTION
 from upparat.statemachine import BaseState
 
 logger = logging.getLogger(__name__)
@@ -128,6 +131,15 @@ class SelectJobState(BaseState):
         if topic_matches_sub(accepted_topic, topic):
             job_execution = payload[EXECUTION]
             job_document = job_execution[JOB_DOCUMENT]
+            job_document_action = job_document.get(JOB_DOCUMENT_ACTION)
+
+            # something else can also publish jobs → make sure to only handle the ones for us
+            if job_document_action != UPPARAT_ACTION:
+                logger.info(
+                    f"Job ignored: Job document does not match expected Upparat action field {UPPARAT_ACTION}."  # noqa
+                )
+                self.publish(Event(SELECT_JOB_ACTION_MISMATCH))
+                return
 
             job = Job(
                 id_=job_execution[JOB_ID],

--- a/tests/statemachine/statemachine_transitions_test.py
+++ b/tests/statemachine/statemachine_transitions_test.py
@@ -16,6 +16,7 @@ from upparat.events import JOB_VERIFIED
 from upparat.events import JOBS_AVAILABLE
 from upparat.events import NO_JOBS_PENDING
 from upparat.events import RESTART_INTERRUPTED
+from upparat.events import SELECT_JOB_ACTION_MISMATCH
 from upparat.events import SELECT_JOB_INTERRUPTED
 from upparat.statemachine.download import DownloadState
 from upparat.statemachine.fetch_jobs import FetchJobsState
@@ -122,6 +123,13 @@ def test_fetch_jobs_pending_jobs_found(fetch_jobs_state):
     statemachine, _ = fetch_jobs_state
     statemachine.dispatch(Event(JOBS_AVAILABLE))
     assert isinstance(statemachine.state, SelectJobState)
+    return statemachine, statemachine.state
+
+
+def test_select_found_job_not_for_upparat(select_job_state):
+    statemachine, _ = select_job_state
+    statemachine.dispatch(Event(SELECT_JOB_ACTION_MISMATCH))
+    assert isinstance(statemachine.state, MonitorState)
     return statemachine, statemachine.state
 
 


### PR DESCRIPTION
Previously, all AWS IoT Jobs would attempt to initiate an update process even if the payload was clearly not meant for Upparat.

With this change, Upparat only handles jobs in whose job document the `action` field is set to `upparat-update`.

I.e. a valid document would look like this:

```
{
  "action": "upparat-update",
  "file": "${aws:iot:s3-presigned-url:https://firmware.s3.amazonaws.com/bundle.raucb}",
  "version": "1.2.0"
}
```

This PR closes https://github.com/caruhome/upparat/issues/13